### PR TITLE
Remove the confusing suffix "-debug" for non-debug mode

### DIFF
--- a/cbf2.sh
+++ b/cbf2.sh
@@ -246,7 +246,7 @@ else
 			then
 				eval "docker run $exposePorts $DOCKER_NETWORK_OPT -p $debugPort:8044 --name $build-debug -e DEBUG=true $volumeList $build"
 			else
-				eval "docker run $exposePorts $DOCKER_NETWORK_OPT --name $build-debug $volumeList $build"
+				eval "docker run $exposePorts $DOCKER_NETWORK_OPT --name $build $volumeList $build"
 			fi
 
 		fi


### PR DESCRIPTION
A suffix "-debug" is added to the container name even for non-debug mode.
This is confusing and please consider to remove it.